### PR TITLE
Updated workflow badge style, badge name and added build status link to the badge

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Python application
+name: Build
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![Linux](https://img.shields.io/badge/Platform-Linux-yellow?style=for-the-badge&logo=linux&logoColor=blue)](https://www.linux.org/)
 
-[![Build](https://img.shields.io/github/actions/workflow/status/CSC510-YTS/HW1/python-app.yml?style=for-the-badge)](https://github.com/CSC510-YTS/HW1/actions/workflows/python-app.yml)
+[![Build](https://img.shields.io/github/actions/workflow/status/CSC510-YTS/HW1/python-app.yml?style=for-the-badge&logo=pytest&logoColor=green)](https://github.com/CSC510-YTS/HW1/actions/workflows/python-app.yml)
 
 [![codecov](https://codecov.io/gh/CSC510-YTS/HW1/graph/badge.svg?token=QFB8RM9WKN)](https://codecov.io/gh/CSC510-YTS/HW1)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![Linux](https://img.shields.io/badge/Platform-Linux-yellow?style=for-the-badge&logo=linux&logoColor=blue)](https://www.linux.org/)
 
-![Build](https://img.shields.io/github/actions/workflow/status/CSC510-YTS/HW1/python-app.yml?style=for-the-badge)
+[![Build](https://img.shields.io/github/actions/workflow/status/CSC510-YTS/HW1/python-app.yml?style=for-the-badge)](https://github.com/CSC510-YTS/HW1/actions/workflows/python-app.yml)
 
 [![codecov](https://codecov.io/gh/CSC510-YTS/HW1/graph/badge.svg?token=QFB8RM9WKN)](https://codecov.io/gh/CSC510-YTS/HW1)
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 
 [![Linux](https://img.shields.io/badge/Platform-Linux-yellow?style=for-the-badge&logo=linux&logoColor=blue)](https://www.linux.org/)
 
-![Test Result](https://github.com/CSC510-YTS/HW1/actions/workflows/python-app.yml/badge.svg)
+![Build](https://img.shields.io/github/actions/workflow/status/CSC510-YTS/HW1/python-app.yml?style=for-the-badge)
 
 [![codecov](https://codecov.io/gh/CSC510-YTS/HW1/graph/badge.svg?token=QFB8RM9WKN)](https://codecov.io/gh/CSC510-YTS/HW1)
+
+Setting up the environment for GitHub Codespaces
+> sudo apt update -y; sudo  apt upgrade -y; sudo apt install software-properties-common -y; sudo add-apt-repository ppa:deadsnakes/ppa -y ; sudo apt update -y ; sudo apt install python3.13 entr -y; pip install pytest pytest-cov;


### PR DESCRIPTION
- Updated the badge name for workflow badge from 'Python Applications' to 'Build'

- Added for-the-badge style to the workflow badge

- Added workflow build status link to the Build badge